### PR TITLE
Trigger autograding with repository_dispatch after incrementing steps

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -101,3 +101,18 @@ jobs:
           branch_name: start-markdown
         env:
           GITHUB_TOKEN: ${{ secrets.GLOBAL_CLASSROOM_ORG_TOKEN }}
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/1-add-headers.yml
+++ b/.github/workflows/1-add-headers.yml
@@ -72,3 +72,18 @@ jobs:
           from_step: 1
           to_step: 2
           branch_name: start-markdown
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/2-add-an-image.yml
+++ b/.github/workflows/2-add-an-image.yml
@@ -72,3 +72,18 @@ jobs:
           from_step: 2
           to_step: 3
           branch_name: start-markdown
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/3-add-a-code-example.yml
+++ b/.github/workflows/3-add-a-code-example.yml
@@ -72,3 +72,18 @@ jobs:
           from_step: 3
           to_step: 4
           branch_name: start-markdown
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/4-make-a-task-list.yml
+++ b/.github/workflows/4-make-a-task-list.yml
@@ -72,3 +72,18 @@ jobs:
           from_step: 4
           to_step: 5
           branch_name: start-markdown
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -65,3 +65,18 @@ jobs:
           from_step: 5
           to_step: X
           branch_name: start-markdown
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Port over the autograding fix from https://github.com/education/primer-copilot/pull/12.

> Tasks performed by the GitHub Actions `GITHUB_TOKEN`, such as commit pushes, [do not create new workflow runs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). This means that the commit and push performed by our `skills/action-update-step@v2` steps are not triggering GitHub Classroom's autograding workflow, which in turn is preventing learners from having their Experience marked as complete after they finish the final step.
>
> The autograding workflow is created with a `repository_dispatch` trigger. This modifies our Actions workflows to manually create a `repository_dispatch` event on the repository after the step update commit has been pushed, causing autograding to run _after_ the `-step.txt` file has received its final update, at which point it will be able to succeed.